### PR TITLE
DM-13123: Doxygen search broken

### DIFF
--- a/bin/makeDocs
+++ b/bin/makeDocs
@@ -305,7 +305,7 @@ def main(topProductName, products, htmlDir, xmlDir, useDot=True):
     config.entries["INLINE_SOURCES"] = "YES"
     config.entries["SOURCE_BROWSER"] = "YES"
     config.entries["SEARCHENGINE"] = "YES"
-    config.entries["SERVER_BASED_SEARCH"] = "YES"
+    config.entries["SERVER_BASED_SEARCH"] = "NO"
     config.entries["HAVE_DOT"] = "YES" if useDot else "NO"
 
     config.entries["HTML_OUTPUT"] = htmlDir


### PR DESCRIPTION
Server-side search has difficulty running on `lsst.codes` (at the very least, PHP is disabled there). This PR disables server-side search for Stack-wide documentation, reverting to the default of client-side (Javascript) search.

Tested by calling `makeDocs`; not tested using `create_xlinkdocs.sh` due to technical difficulties getting it to build anything other than `master`.